### PR TITLE
fixed text in counter widget

### DIFF
--- a/example/lib/widgets/counter_widget.dart
+++ b/example/lib/widgets/counter_widget.dart
@@ -47,7 +47,7 @@ class CounterWidget extends StatelessWidget {
                     state: (bloc) => bloc.states.decrementEnabled,
                     builder: (context, snapshot, bloc) => Expanded(
                       child: RaisedButton(
-                        child: Text('Increment'),
+                        child: Text('Decrement'),
                         onPressed: (snapshot.data ?? false)
                             ? bloc.events.decrement
                             : null,


### PR DESCRIPTION
The counter widget in the example had two buttons with the text 'Increment', changed the decrement button's text to 'Decrement'